### PR TITLE
Complete installation instructions for Debian Jessie

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,15 @@
 - A Dotbot configuration file in that repository
 - Python 3
 
+#### Dependencies installation
+
+##### Debian Jessie
+
+On Debian Jessie, run the following commands:
+
+    # apt-get install libgit2-dev python3-cffi python3-yaml
+    # pip3 install -r requirements.txt
+
 
 ### Instructions
 Save `pre-commit` and `prepare-commit-msg` to `.git/hooks` in your dotfiles directory. Alternatively, use a Git hook manager like [git-hooks](https://github.com/git-hooks/git-hooks).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pygit2
+pygit2==0.21.1
 pyyaml
 unidiff


### PR DESCRIPTION
Tested on Debian Jessie 8.6

Closes #1

At the moment, I used the original `requirements.txt` to force `pygit2` in v0.21.1. But maybe it is a good practice to separate in another `requirements.txt` (let's say `requirements-debian-jessie.txt`). Just tell me what you prefer and I will push another commit to fix that.
