### PR TITLE
Add support for pre-commit by Yelp

### DIFF
--- a/hooks.yaml
+++ b/hooks.yaml
@@ -1,0 +1,5 @@
+-   id: autobot
+    name: Autobot
+    entry: pre-commit
+    language: python
+    description: Automatically update your Dotbot config file when you add files in Git


### PR DESCRIPTION
This allows to have a seamless integration of your hook with [pre-commit by Yelp](http://pre-commit.com/).

To use it, just add in your dotfiles repo a `.pre-commit-config.yaml`:

``` yaml
- repo: https://github.com/gwerbin/dotbot-autobot
  hooks:
    - id: autobot
```

Tested with [my dotfiles](https://github.com/nagromc/dotfiles/commit/58b0d094b77506745604ea757190ae4efad7061e#diff-82c3b36709926de3a1b27bea0d8258ccR15).
